### PR TITLE
Fix product store relation and add feature coverage

### DIFF
--- a/src/app/Models/Product.php
+++ b/src/app/Models/Product.php
@@ -19,7 +19,8 @@ class Product extends Model
 
     public function stores(): BelongsToMany
     {
-        return $this->belongsToMany(Store::class)->withTimestamps();
+        return $this->belongsToMany(Store::class, 'product_store', 'product_id', 'store_id')
+            ->withTimestamps();
     }
 
     public function scopeAvailableForStore($query, int $storeId)

--- a/src/database/factories/ProductFactory.php
+++ b/src/database/factories/ProductFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\Product>
+ */
+class ProductFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'sku' => fake()->unique()->bothify('PROD-####'),
+            'name' => fake()->words(3, true),
+            'description' => fake()->sentence(),
+            'price' => fake()->numberBetween(1000, 10000),
+            'manufacturer' => fake()->company(),
+            'is_active' => true,
+            'is_all_store' => false,
+        ];
+    }
+}

--- a/src/database/factories/StoreFactory.php
+++ b/src/database/factories/StoreFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\Store>
+ */
+class StoreFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'code' => fake()->unique()->bothify('STORE-###'),
+            'name' => fake()->company(),
+            'address' => fake()->address(),
+            'phone' => fake()->phoneNumber(),
+            'open_time' => '09:00',
+            'close_time' => '18:00',
+            'is_active' => true,
+        ];
+    }
+}

--- a/src/database/factories/UserFactory.php
+++ b/src/database/factories/UserFactory.php
@@ -29,6 +29,8 @@ class UserFactory extends Factory
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
+            'role' => 'hq',
+            'store_id' => null,
         ];
     }
 

--- a/src/tests/Feature/ProductManagementTest.php
+++ b/src/tests/Feature/ProductManagementTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Product;
+use App\Models\Store;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ProductManagementTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_product_index_displays_attached_store_names(): void
+    {
+        $user = User::factory()->create();
+        $store = Store::factory()->create(['name' => 'テスト店舗']);
+        $product = Product::factory()->create(['name' => 'テスト商品']);
+        $product->stores()->attach($store);
+
+        $response = $this->actingAs($user)->get('/products');
+
+        $response->assertOk();
+        $response->assertSee('テスト商品');
+        $response->assertSee('テスト店舗');
+    }
+}


### PR DESCRIPTION
## Summary
- ensure the product-to-store relation explicitly targets the product_store pivot table
- add product and store factories and update the user factory defaults for HQ role access
- cover the product index flow with a feature test that asserts attached stores render correctly

## Testing
- composer install *(fails: GitHub API requires authentication for package downloads)*

------
https://chatgpt.com/codex/tasks/task_e_68ccc8a9d2fc8327b7448342e6f1bf2c