### PR TITLE
Add minimal seed data for initial setup

### DIFF
--- a/src/database/seeders/CampaignSeeder.php
+++ b/src/database/seeders/CampaignSeeder.php
@@ -13,7 +13,31 @@ class CampaignSeeder extends Seeder
      */
     public function run(): void
     {
-        Campaign::create(['name'=>'おせち2025','description'=>'おせち予約','start_date'=>'2025-10-01','end_date'=>'2025-12-25']);
-        Campaign::create(['name'=>'恵方巻2026','description'=>'節分企画','start_date'=>'2026-01-10','end_date'=>'2026-02-03']);
+        $campaigns = [
+            [
+                'name' => 'おせち2025',
+                'description' => 'おせち予約',
+                'start_date' => '2025-10-01',
+                'end_date' => '2025-12-25',
+            ],
+            [
+                'name' => '恵方巻2026',
+                'description' => '節分企画',
+                'start_date' => '2026-01-10',
+                'end_date' => '2026-02-03',
+            ],
+        ];
+
+        foreach ($campaigns as $campaign) {
+            Campaign::updateOrCreate(
+                ['name' => $campaign['name']],
+                [
+                    'description' => $campaign['description'],
+                    'start_date' => $campaign['start_date'],
+                    'end_date' => $campaign['end_date'],
+                    'is_active' => true,
+                ]
+            );
+        }
     }
 }

--- a/src/database/seeders/DatabaseSeeder.php
+++ b/src/database/seeders/DatabaseSeeder.php
@@ -17,12 +17,11 @@ class DatabaseSeeder extends Seeder
         // User::factory(10)->create();
 
         $this->call([
-//            StoreSeeder::class,
-//            CampaignSeeder::class,
-//            ProductSeeder::class,
-//            CampaignProductStoreSeeder::class,
+            StoreSeeder::class,
+            CampaignSeeder::class,
+            ProductSeeder::class,
+            CampaignProductStoreSeeder::class,
             UserSeeder::class,
-//            ReservationDemoSeeder::class,
         ]);
     }
 }

--- a/src/database/seeders/ProductSeeder.php
+++ b/src/database/seeders/ProductSeeder.php
@@ -13,8 +13,39 @@ class ProductSeeder extends Seeder
      */
     public function run(): void
     {
-        Product::create(['sku'=>'OC-001','name'=>'おせち三段重','price'=>25000,'manufacturer'=>'メーカーA']);
-        Product::create(['sku'=>'OC-002','name'=>'おせち二段重','price'=>18000,'manufacturer'=>'メーカーA']);
-        Product::create(['sku'=>'EH-001','name'=>'恵方巻（上）','price'=>1200,'manufacturer'=>'メーカーB']);
+        $products = [
+            [
+                'sku' => 'OC-001',
+                'name' => 'おせち三段重',
+                'price' => 25000,
+                'manufacturer' => 'メーカーA',
+            ],
+            [
+                'sku' => 'OC-002',
+                'name' => 'おせち二段重',
+                'price' => 18000,
+                'manufacturer' => 'メーカーA',
+            ],
+            [
+                'sku' => 'EH-001',
+                'name' => '恵方巻（上）',
+                'price' => 1200,
+                'manufacturer' => 'メーカーB',
+            ],
+        ];
+
+        foreach ($products as $product) {
+            Product::updateOrCreate(
+                ['sku' => $product['sku']],
+                [
+                    'name' => $product['name'],
+                    'price' => $product['price'],
+                    'manufacturer' => $product['manufacturer'],
+                    'description' => $product['description'] ?? null,
+                    'is_active' => true,
+                    'is_all_store' => true,
+                ]
+            );
+        }
     }
 }

--- a/src/database/seeders/StoreSeeder.php
+++ b/src/database/seeders/StoreSeeder.php
@@ -13,8 +13,45 @@ class StoreSeeder extends Seeder
      */
     public function run(): void
     {
-        Store::create(['code'=>'S01','name'=>'本店','address'=>'〇〇市1-1','phone'=>'090-0000-0001','open_time'=>'09:00','close_time'=>'20:00']);
-        Store::create(['code'=>'S02','name'=>'南店','address'=>'〇〇市2-2','phone'=>'090-0000-0002','open_time'=>'09:00','close_time'=>'20:00']);
-        Store::create(['code'=>'S03','name'=>'北店','address'=>'〇〇市3-3','phone'=>'090-0000-0003','open_time'=>'09:00','close_time'=>'20:00']);
+        $stores = [
+            [
+                'code' => 'S01',
+                'name' => '本店',
+                'address' => '〇〇市1-1',
+                'phone' => '090-0000-0001',
+                'open_time' => '09:00',
+                'close_time' => '20:00',
+            ],
+            [
+                'code' => 'S02',
+                'name' => '南店',
+                'address' => '〇〇市2-2',
+                'phone' => '090-0000-0002',
+                'open_time' => '09:00',
+                'close_time' => '20:00',
+            ],
+            [
+                'code' => 'S03',
+                'name' => '北店',
+                'address' => '〇〇市3-3',
+                'phone' => '090-0000-0003',
+                'open_time' => '09:00',
+                'close_time' => '20:00',
+            ],
+        ];
+
+        foreach ($stores as $store) {
+            Store::updateOrCreate(
+                ['code' => $store['code']],
+                [
+                    'name' => $store['name'],
+                    'address' => $store['address'],
+                    'phone' => $store['phone'],
+                    'open_time' => $store['open_time'],
+                    'close_time' => $store['close_time'],
+                    'is_active' => true,
+                ]
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary
- make store, campaign, and product seeders idempotent and mark essential attributes
- seed campaign-product-store links with deterministic initial quantities
- enable the minimal seeders from DatabaseSeeder so required records exist by default

## Testing
- `php artisan test` *(fails: missing vendor/autoload.php in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ccd12e9dc08327a3926647c45a7318