### PR TITLE
Add campaign store participation and product assignments

### DIFF
--- a/src/app/Http/Controllers/CampaignProductStoreController.php
+++ b/src/app/Http/Controllers/CampaignProductStoreController.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Campaign;
+use App\Models\CampaignProductStore;
+use App\Models\Product;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+class CampaignProductStoreController extends Controller
+{
+    public function store(Request $request, Campaign $campaign): RedirectResponse
+    {
+        $data = $request->validate([
+            'store_id' => ['required', Rule::exists('stores', 'id')],
+            'product_id' => ['required', Rule::exists('products', 'id')],
+            'planned_quantity' => ['nullable', 'integer', 'min:0'],
+            'is_available' => ['required', 'boolean'],
+        ]);
+
+        if (!$campaign->stores()->whereKey($data['store_id'])->exists()) {
+            return back()->withErrors(['store_id' => '選択した店舗は企画に参加していません。'])->withInput();
+        }
+
+        $productAvailable = Product::whereKey($data['product_id'])
+            ->availableForStore($data['store_id'])
+            ->exists();
+
+        if (!$productAvailable) {
+            return back()->withErrors(['product_id' => '選択された商品は店舗で取り扱っていません。'])->withInput();
+        }
+
+        $exists = CampaignProductStore::where([
+            'campaign_id' => $campaign->id,
+            'store_id' => $data['store_id'],
+            'product_id' => $data['product_id'],
+        ])->exists();
+
+        if ($exists) {
+            return back()->withErrors(['product_id' => '既に設定済みの組み合わせです。'])->withInput();
+        }
+
+        CampaignProductStore::create([
+            'campaign_id' => $campaign->id,
+            'store_id' => $data['store_id'],
+            'product_id' => $data['product_id'],
+            'planned_quantity' => $data['planned_quantity'] ?? 0,
+            'reserved_quantity' => 0,
+            'is_available' => (bool)$data['is_available'],
+        ]);
+
+        return back()->with('status', '企画の商品設定を追加しました');
+    }
+
+    public function update(Request $request, Campaign $campaign, CampaignProductStore $productStore): RedirectResponse
+    {
+        abort_unless($productStore->campaign_id === $campaign->id, 404);
+
+        $data = $request->validate([
+            'planned_quantity' => ['required', 'integer', 'min:0'],
+            'is_available' => ['required', 'boolean'],
+        ]);
+
+        $productStore->update([
+            'planned_quantity' => $data['planned_quantity'],
+            'is_available' => (bool)$data['is_available'],
+        ]);
+
+        return back()->with('status', '企画の商品設定を更新しました');
+    }
+
+    public function destroy(Campaign $campaign, CampaignProductStore $productStore): RedirectResponse
+    {
+        abort_unless($productStore->campaign_id === $campaign->id, 404);
+
+        $productStore->delete();
+
+        return back()->with('status', '企画の商品設定を削除しました');
+    }
+}

--- a/src/app/Models/Campaign.php
+++ b/src/app/Models/Campaign.php
@@ -4,6 +4,8 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Campaign extends Model
 {
@@ -11,11 +13,24 @@ class Campaign extends Model
 
     protected $fillable = ['name', 'description', 'start_date', 'end_date', 'is_active'];
 
+    protected $casts = [
+        'is_active' => 'boolean',
+    ];
 
-    public function products()
+    public function products(): BelongsToMany
     {
         return $this->belongsToMany(Product::class, 'campaign_product_store')
             ->withPivot(['store_id', 'planned_quantity', 'reserved_quantity', 'is_available'])
             ->withTimestamps();
+    }
+
+    public function stores(): BelongsToMany
+    {
+        return $this->belongsToMany(Store::class, 'campaign_store')->withTimestamps();
+    }
+
+    public function productStores(): HasMany
+    {
+        return $this->hasMany(CampaignProductStore::class);
     }
 }

--- a/src/app/Models/CampaignProductStore.php
+++ b/src/app/Models/CampaignProductStore.php
@@ -3,9 +3,29 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class CampaignProductStore extends Model
 {
     protected $table = 'campaign_product_store';
     protected $fillable = ['campaign_id', 'product_id', 'store_id', 'planned_quantity', 'reserved_quantity', 'is_available'];
+
+    protected $casts = [
+        'is_available' => 'boolean',
+    ];
+
+    public function campaign(): BelongsTo
+    {
+        return $this->belongsTo(Campaign::class);
+    }
+
+    public function product(): BelongsTo
+    {
+        return $this->belongsTo(Product::class);
+    }
+
+    public function store(): BelongsTo
+    {
+        return $this->belongsTo(Store::class);
+    }
 }

--- a/src/app/Models/Store.php
+++ b/src/app/Models/Store.php
@@ -23,4 +23,9 @@ class Store extends Model
     {
         return $this->belongsToMany(Product::class)->withTimestamps();
     }
+
+    public function campaigns(): BelongsToMany
+    {
+        return $this->belongsToMany(Campaign::class, 'campaign_store')->withTimestamps();
+    }
 }

--- a/src/database/migrations/2025_09_18_070000_create_campaign_store_table.php
+++ b/src/database/migrations/2025_09_18_070000_create_campaign_store_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('campaign_store', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('campaign_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('store_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+            $table->unique(['campaign_id', 'store_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('campaign_store');
+    }
+};

--- a/src/resources/views/masters/campaigns/form.blade.php
+++ b/src/resources/views/masters/campaigns/form.blade.php
@@ -19,7 +19,7 @@
 
     <form method="post"
           action="{{ $campaign->exists ? route('campaigns.update', $campaign) : route('campaigns.store') }}"
-          class="space-y-4">
+          class="space-y-6">
         @csrf
         @if($campaign->exists) @method('PUT') @endif
 
@@ -59,6 +59,22 @@
             </div>
         </div>
 
+        <div>
+            <div class="form-label">参加店舗 <span class="text-red-600">*</span></div>
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-2">
+                @foreach($stores as $store)
+                    <label class="inline-flex items-center gap-2">
+                        <input type="checkbox" name="store_ids[]" value="{{ $store->id }}"
+                               {{ in_array($store->id, old('store_ids', $selectedStoreIds ?? []), true) ? 'checked' : '' }}>
+                        <span>{{ $store->name }}</span>
+                    </label>
+                @endforeach
+            </div>
+            @error('store_ids') <div class="form-error">{{ $message }}</div> @enderror
+            @error('store_ids.*') <div class="form-error">{{ $message }}</div> @enderror
+            <div class="text-xs text-slate-500 mt-1">保存後に各店舗ごとの商品を設定できます。</div>
+        </div>
+
         <div class="flex items-center gap-2">
             <button class="btn-primary">保存</button>
             <a href="{{ route('campaigns.index') }}" class="px-3 py-2 rounded border">戻る</a>
@@ -72,4 +88,102 @@
             @endif
         </div>
     </form>
+
+    @if($campaign->exists)
+        <hr class="my-8">
+
+        <div class="space-y-6">
+            <h3 class="text-lg font-semibold">企画商品設定</h3>
+
+            <form method="post" action="{{ route('campaigns.products.store', $campaign) }}" class="grid grid-cols-1 md:grid-cols-5 gap-4 items-end">
+                @csrf
+                <div class="md:col-span-2">
+                    <label class="form-label">店舗 <span class="text-red-600">*</span></label>
+                    <select name="store_id" class="form-input" required>
+                        <option value="">選択してください</option>
+                        @foreach($campaign->stores as $store)
+                            <option value="{{ $store->id }}" @selected(old('store_id')==$store->id)>{{ $store->name }}</option>
+                        @endforeach
+                    </select>
+                    @error('store_id') <div class="form-error">{{ $message }}</div> @enderror
+                </div>
+                <div class="md:col-span-2">
+                    <label class="form-label">商品 <span class="text-red-600">*</span></label>
+                    <select name="product_id" class="form-input" required>
+                        <option value="">選択してください</option>
+                        @foreach($productOptions as $product)
+                            <option value="{{ $product->id }}" @selected(old('product_id')==$product->id)>
+                                {{ $product->name }}
+                            </option>
+                        @endforeach
+                    </select>
+                    @error('product_id') <div class="form-error">{{ $message }}</div> @enderror
+                </div>
+                <div>
+                    <label class="form-label">計画数量</label>
+                    <input type="number" name="planned_quantity" min="0" class="form-input" value="{{ old('planned_quantity', 0) }}">
+                    @error('planned_quantity') <div class="form-error">{{ $message }}</div> @enderror
+                </div>
+                <div class="flex items-center gap-2">
+                    <input type="hidden" name="is_available" value="0">
+                    <label class="inline-flex items-center gap-2">
+                        <input type="checkbox" name="is_available" value="1" {{ old('is_available', 1) ? 'checked' : '' }}>
+                        有効
+                    </label>
+                    <button class="btn-primary">追加</button>
+                </div>
+            </form>
+
+            <div class="overflow-x-auto">
+                <table class="min-w-full text-sm border">
+                    <thead>
+                        <tr class="bg-slate-100 text-left">
+                            <th class="px-3 py-2 border">店舗</th>
+                            <th class="px-3 py-2 border">商品</th>
+                            <th class="px-3 py-2 border">計画数量</th>
+                            <th class="px-3 py-2 border">状態</th>
+                            <th class="px-3 py-2 border w-48">操作</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse($productStores as $row)
+                            <tr>
+                                <td class="px-3 py-2 border">{{ $row->store->name }}</td>
+                                <td class="px-3 py-2 border">{{ $row->product->name }}</td>
+                                <td class="px-3 py-2 border">
+                                    <form method="post" action="{{ route('campaigns.products.update', [$campaign, $row]) }}" class="flex items-center gap-2">
+                                        @csrf
+                                        @method('PUT')
+                                        <input type="number" name="planned_quantity" min="0" class="form-input w-24"
+                                               value="{{ $row->planned_quantity }}">
+                                        <select name="is_available" class="form-input w-32">
+                                            <option value="1" {{ $row->is_available ? 'selected' : '' }}>有効</option>
+                                            <option value="0" {{ !$row->is_available ? 'selected' : '' }}>停止</option>
+                                        </select>
+                                        <button class="px-3 py-1 bg-blue-600 text-white rounded">更新</button>
+                                    </form>
+                                </td>
+                                <td class="px-3 py-2 border">
+                                    <span class="px-2 py-1 rounded text-xs {{ $row->is_available ? 'bg-emerald-100 text-emerald-700' : 'bg-slate-100 text-slate-600' }}">
+                                        {{ $row->is_available ? '販売中' : '停止中' }}
+                                    </span>
+                                </td>
+                                <td class="px-3 py-2 border">
+                                    <form method="post" action="{{ route('campaigns.products.destroy', [$campaign, $row]) }}" onsubmit="return confirm('削除しますか？');">
+                                        @csrf
+                                        @method('DELETE')
+                                        <button class="px-3 py-1 rounded bg-red-600 text-white">削除</button>
+                                    </form>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="5" class="px-3 py-4 text-center text-slate-500">設定済みの商品がありません。</td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    @endif
 @endsection

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -31,6 +31,9 @@ Route::middleware('auth')->group(function () {
 
     // マスタ管理
     Route::resource('campaigns', \App\Http\Controllers\CampaignController::class)->except(['show']);
+    Route::post('campaigns/{campaign}/products', [\App\Http\Controllers\CampaignProductStoreController::class, 'store'])->name('campaigns.products.store');
+    Route::put('campaigns/{campaign}/products/{productStore}', [\App\Http\Controllers\CampaignProductStoreController::class, 'update'])->name('campaigns.products.update');
+    Route::delete('campaigns/{campaign}/products/{productStore}', [\App\Http\Controllers\CampaignProductStoreController::class, 'destroy'])->name('campaigns.products.destroy');
     Route::resource('products', \App\Http\Controllers\ProductController::class)->except(['show']);
     Route::resource('stores', \App\Http\Controllers\StoreController::class)->except(['show']);
 

--- a/src/tests/Feature/ReservationCampaignConstraintTest.php
+++ b/src/tests/Feature/ReservationCampaignConstraintTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Campaign;
+use App\Models\CampaignProductStore;
+use App\Models\Product;
+use App\Models\Store;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ReservationCampaignConstraintTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function validPayload(Campaign $campaign, Store $store, Product $product): array
+    {
+        return [
+            'campaign_id' => $campaign->id,
+            'store_id' => $store->id,
+            'channel' => 'store',
+            'customer_name' => 'テスト太郎',
+            'phone' => '09012345678',
+            'items' => [
+                ['product_id' => $product->id, 'quantity' => 1],
+            ],
+        ];
+    }
+
+    public function test_store_must_belong_to_campaign(): void
+    {
+        $user = User::factory()->create();
+        $campaign = Campaign::create([
+            'name' => 'テスト企画',
+            'start_date' => now()->toDateString(),
+            'is_active' => true,
+        ]);
+        $store = Store::factory()->create();
+        $product = Product::factory()->create();
+        $product->stores()->attach($store);
+
+        $response = $this->actingAs($user)->from('/reservations/create')->post('/reservations', $this->validPayload($campaign, $store, $product));
+
+        $response->assertSessionHasErrors('store_id');
+        $this->assertDatabaseCount('reservations', 0);
+    }
+
+    public function test_products_must_be_linked_via_campaign_store(): void
+    {
+        $user = User::factory()->create();
+        $campaign = Campaign::create([
+            'name' => 'テスト企画',
+            'start_date' => now()->toDateString(),
+            'is_active' => true,
+        ]);
+        $store = Store::factory()->create();
+        $product = Product::factory()->create();
+        $product->stores()->attach($store);
+        $campaign->stores()->attach($store);
+
+        $response = $this->actingAs($user)->from('/reservations/create')->post('/reservations', $this->validPayload($campaign, $store, $product));
+        $response->assertSessionHasErrors('items');
+
+        CampaignProductStore::create([
+            'campaign_id' => $campaign->id,
+            'store_id' => $store->id,
+            'product_id' => $product->id,
+            'planned_quantity' => 5,
+            'reserved_quantity' => 0,
+            'is_available' => true,
+        ]);
+
+        $response = $this->actingAs($user)->from('/reservations/create')->post('/reservations', $this->validPayload($campaign, $store, $product));
+        $response->assertRedirect('/reservations');
+        $this->assertDatabaseHas('reservations', [
+            'campaign_id' => $campaign->id,
+            'store_id' => $store->id,
+            'customer_name' => 'テスト太郎',
+        ]);
+        $this->assertDatabaseHas('campaign_product_store', [
+            'campaign_id' => $campaign->id,
+            'store_id' => $store->id,
+            'product_id' => $product->id,
+            'reserved_quantity' => 1,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- allow campaign forms to manage participating stores and add per-store product assignments with planned quantities
- enforce campaign/store/product availability throughout reservation validation and price preview while updating the reservation UI to filter choices
- add database support for campaign-store relationships and automated tests covering campaign restrictions on reservations

## Testing
- ⚠️ `composer install`


------
https://chatgpt.com/codex/tasks/task_e_68cce36341dc832788aa6bc59f000f7c