### PR TITLE
Optimize reservation item validation

### DIFF
--- a/src/app/Http/Controllers/ReservationController.php
+++ b/src/app/Http/Controllers/ReservationController.php
@@ -171,7 +171,7 @@ class ReservationController extends Controller
             'store_id'    => ['required','exists:stores,id'],
             'channel'     => ['nullable', \Illuminate\Validation\Rule::in(['store','tokushimaru','web'])],
             'items'       => ['required','array','min:1'],
-            'items.*.product_id' => ['required','exists:products,id'],
+            'items.*.product_id' => ['required','integer','min:1'],
             'items.*.quantity'   => ['required','integer','min:1'],
         ]);
 


### PR DESCRIPTION
## Summary
- replace the per-item `exists` validation with integer checks and a consolidated product lookup so reservation creation no longer triggers thousands of database queries
- apply the same lightweight validation to the price preview endpoint for consistency

## Testing
- php -l src/app/Http/Requests/StoreReservationRequest.php
- php -l src/app/Http/Controllers/ReservationController.php

------
https://chatgpt.com/codex/tasks/task_e_68ccedc083f883278dc22e53d5143406