### PR TITLE
Limit campaign product options per store

### DIFF
--- a/src/resources/views/masters/campaigns/form.blade.php
+++ b/src/resources/views/masters/campaigns/form.blade.php
@@ -20,6 +20,7 @@
     @php
         $defaultSelectedStoreIds = $selectedStoreIds ?? [];
         $defaultStoreProductSelections = $storeProductSelections ?? [];
+        $storeProductOptions = $storeProductOptions ?? [];
         $selectedStoreIds = collect(old('store_ids', $defaultSelectedStoreIds))
             ->map(fn($id) => (int) $id)
             ->filter()
@@ -111,9 +112,9 @@
                                     multiple
                                     size="5"
                                     {{ $isChecked ? '' : 'disabled' }}>
-                                @foreach($products as $product)
-                                    <option value="{{ $product->id }}" @selected(in_array($product->id, $selectedProducts, true))>
-                                        {{ $product->name }}
+                                @foreach($storeProductOptions[$store->id] ?? [] as $product)
+                                    <option value="{{ $product['id'] }}" @selected(in_array($product['id'], $selectedProducts, true))>
+                                        {{ $product['name'] }}
                                     </option>
                                 @endforeach
                             </select>


### PR DESCRIPTION
## Summary
- load store-specific product options so the campaign form only lists items the store can sell (common + store assignments)
- expose those options to the Blade form and render store-specific selects accordingly
- add a feature test that verifies each store only sees its available products

## Testing
- php artisan test *(fails: composer install requires a GitHub token in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd1817d1f88327bec8d5a575e96f59